### PR TITLE
Fix plugin import error by updating sys.path and adding __init__.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ sys.path.extend(
         path.as_posix()
         for path in (
             root,
+            root / "plugin",
             root / "lib",
             root / "lib" / "win32",
             root / "lib" / "win32" / "lib",


### PR DESCRIPTION
## Summary

This pull request fixes a `ModuleNotFoundError` / `ImportError` that occurs when trying to run the plugin due to an incorrect import path in `main.py`.

The plugin attempts to import `ScreenBrightnessPlugin` from `plugin.plugin`, but the `plugin` folder isn't recognized as a package, and it's not included in `sys.path`. This causes the plugin to crash when loaded in Flow Launcher.

**Fix:**

* Add the `plugin` directory to `sys.path` in `main.py`.
* Add an empty `__init__.py` inside the `plugin` directory to make it a proper Python package.

These changes allow the plugin to load successfully in Flow Launcher without raising an exception.

## Checklist

* [x] If code changes were made then they have been tested.

  * [ ] I have updated the documentation to reflect the changes.
* [x] This PR fixes an issue.
* [ ] This PR adds something new (e.g. new method or parameters).
* [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
* [ ] This PR is **not** a code change (e.g. documentation, README, ...)
